### PR TITLE
As dev i want to simplify and flexibilize the workflow and use the stable actions to improve it according to user experiences

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: fix
 assignees: ''
 
 ---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,15 +6,7 @@ Please include a summary of the change and which issue is fixed. Please also inc
 
 Please add linking to issue fixes. Follow the [recommendations](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
 
-Fixes # (issue)
-
-## Type of change
-
-Please delete options that are not relevant.
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+Fixes #(issue)
 
 # How Has This Been Tested?
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,7 +8,7 @@ changelog:
         - feature
     - title: 'Fixes :bug:'
       labels:
-        - bug
+        - fix
     - title: Other Changes
       labels:
         - "*"

--- a/.github/workflows/labels-test.yml
+++ b/.github/workflows/labels-test.yml
@@ -38,13 +38,13 @@ jobs:
                 labels: ['BREAKING CHANGE']
               - type: 'documentation'
                 nouns: ['doc','docu','document','documentation']
-                labels: ['documentation']
+                labels: ['documentation','fix']
               - type: 'build'
                 nouns: ['build','rebuild']
                 labels: ['build','fix']
               - type: 'config'
                 nouns: ['config', 'conf', 'cofiguration', 'configure']
-                labels: ['config']
+                labels: ['config','fix']
 
       - name: Verify labels
         id: action-verify-labels

--- a/.github/workflows/labels-test.yml
+++ b/.github/workflows/labels-test.yml
@@ -29,7 +29,7 @@ jobs:
             conventional-commits:
               - type: 'fix'
                 nouns: ['FIX', 'Fix', 'fix', 'FIXED', 'Fixed', 'fixed']
-                labels: ['bug']
+                labels: ['fix']
               - type: 'feature'
                 nouns: ['FEATURE', 'Feature', 'feature', 'FEAT', 'Feat', 'feat']
                 labels: ['feature']
@@ -41,7 +41,7 @@ jobs:
                 labels: ['documentation']
               - type: 'build'
                 nouns: ['build','rebuild']
-                labels: ['build','bug']
+                labels: ['build','fix']
               - type: 'config'
                 nouns: ['config', 'conf', 'cofiguration', 'configure']
                 labels: ['config']
@@ -51,7 +51,7 @@ jobs:
         uses: mauroalderete/action-verify-labels@v1
         with:
           none: question, wontfix, invalid
-          some: bug, feature, BREAKING CHANGE
+          some: fix, feature, BREAKING CHANGE
           request-review: true
           request-review-header: '**:bookmark: verify-labels-action**'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labels-test.yml
+++ b/.github/workflows/labels-test.yml
@@ -7,8 +7,8 @@ on:
       [opened, reopened, synchronize, labeled, unlabeled]
 
 jobs:
-  assign-labels:
-    name: Assign labels from conventional-commits
+  labels-test:
+    name: Assign and test labels from conventional-commits
     if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     outputs:
@@ -24,7 +24,6 @@ jobs:
         id: action-assign-labels
         uses: ./
         with:
-          pull-request-number: ${{ github.event.pull_request.number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           conventional-commits: |
             conventional-commits:
@@ -46,19 +45,6 @@ jobs:
               - type: 'config'
                 nouns: ['config', 'conf', 'cofiguration', 'configure']
                 labels: ['config']
-          maintain-labels-not-matched: false
-          apply-changes: true
-
-  verify-labels:
-    runs-on: ubuntu-latest
-    name: Verify labels
-    needs: assign-labels
-    if: github.event.pull_request.merged == false && (needs.assign-labels.outputs.labels-assigned != '[]' || needs.assign-labels.outputs.labels-removed != '[]')
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: v0
 
       - name: Verify labels
         id: action-verify-labels

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -28,7 +28,7 @@ jobs:
           branch: main
           majorList: BREAKING CHANGE, BREAKING, MAJOR
           minorList: FEATURE, Feature, feature, FEAT, Feat, feat
-          patchList: FIX, Fix, fix, FIXED, Fixed, fixed
+          patchList: FIX, Fix, fix, FIXED, Fixed, fixed, config, conf, cofiguration, configure, build, rebuild, doc, docu, document, documentation
           patchAll: false
       
       - name: Push tags


### PR DESCRIPTION
# Description

After using the workflow for this action for many days, I saw some improvements that I achieve implement in this PR:

- Simplify the workflow by using a single job instead of two. This is because on occasion, is needed to run the verification, even if the assignment step doesn't produce any change.
- Use the stable version of the public repository of the action-assign-label.
- Update the job's names and steps to them to be more comprehensible.
- The action-verify-label must be executed with the latest changes proposed by the pull request that triggers the event.
- Rename bug by fix label name to reduce potential confusion about commits and issues.
- Add fix label when a build, conf, or doctype commits is found. This allows guaranteeing a patch bump.

## Type of change

Configuration
