### PR TITLE
build(deps): add a new noun to support build deps

### DIFF
--- a/.github/workflows/labels-test.yml
+++ b/.github/workflows/labels-test.yml
@@ -40,7 +40,7 @@ jobs:
                 nouns: ['doc','docu','document','documentation']
                 labels: ['documentation','fix']
               - type: 'build'
-                nouns: ['build','rebuild', 'build(deps)']
+                nouns: ['build','rebuild', 'build(deps)', 'build(deps-dev)']
                 labels: ['build','fix']
               - type: 'config'
                 nouns: ['config', 'conf', 'cofiguration', 'configure']

--- a/.github/workflows/labels-test.yml
+++ b/.github/workflows/labels-test.yml
@@ -40,7 +40,7 @@ jobs:
                 nouns: ['doc','docu','document','documentation']
                 labels: ['documentation','fix']
               - type: 'build'
-                nouns: ['build','rebuild']
+                nouns: ['build','rebuild', 'build(deps)']
                 labels: ['build','fix']
               - type: 'config'
                 nouns: ['config', 'conf', 'cofiguration', 'configure']


### PR DESCRIPTION
# Description

Did not detect labels when the noun was build(deps)

# Fixes

Fixes #20 

# How Has This Been Tested?

- [x] Unit Tests
- [ x]  Generating this pull request
